### PR TITLE
feat: feature to add timeout to read method in SSHReader object

### DIFF
--- a/asyncssh/stream.py
+++ b/asyncssh/stream.py
@@ -134,7 +134,7 @@ class SSHReader(Generic[AnyStr]):
 
         self._session.eof_received()
 
-    async def read(self, n: int = -1, timeout: int = 2) -> AnyStr:
+    async def read(self, n: int = -1, timeout: int = 10) -> AnyStr:
         """Read data from the stream
 
            This method is a coroutine which reads up to `n` bytes
@@ -146,6 +146,10 @@ class SSHReader(Generic[AnyStr]):
 
            If the next data in the stream is a signal, the signal is
            delivered as a raised exception.
+
+           Args:
+            n: int - Number of bytes or characters to read upto.
+            timeout: int - Number of seconds after which read will return, default is 10
 
            .. note:: Unlike traditional `asyncio` stream readers,
                      the data will be delivered as either `bytes` or
@@ -526,7 +530,7 @@ class SSHStreamSession(Generic[AnyStr]):
         for datatype in self._drain_waiters:
             self._unblock_drain(datatype)
 
-    async def read(self, datatype: DataType, n: int, exact: bool, timeout: int = 2) -> AnyStr:
+    async def read(self, datatype: DataType, n: int, exact: bool, timeout: int = 10) -> AnyStr:
         """Read data from the channel"""
 
         recv_buf = self._recv_buf[datatype]


### PR DESCRIPTION
Added a method parameter `timeout: int` in read method of SSHReader object, this parameter will allow user to enter number of seconds that read method must wait before returning the default is 10 seconds

This is important when you want to execute multiple commands in a for loop and read combined output and some of those commands will generate output while other commands won't generate output, in such scenario this feature will play an importan role.

Example Code
```
from typing import List
import asyncio, asyncssh, sys


class MySSHClient(asyncssh.SSHClient):
    def __init__(self):
        super().__init__()
    
    password = "dummy-pass"

    def kbdint_auth_requested(self):
        # Return empty string to let the server choose submethods
        return ''

    def kbdint_challenge_received(self, name, instructions, lang, prompts):
        # For each prompt, respond with the stored password
        if prompts:
            return [self.password] * len(prompts)
        else:
            return []
    
class Device:
    def __init__(self, ip: str, username: str, password: str):
        self.ip = ip
        self.username = username
        self.password = password

    async def execute_commands(self, commands: List[str]) -> str:
        conn, client = await asyncssh.create_connection(MySSHClient, self.ip, port=22, username=self.username, 
                                                        password=self.password, known_hosts=None, )
        stdin, stdout, stderr = await conn.open_session()
        result = ""
        for cmd in commands:
            stdin.write(f"{cmd}\n")
            print(f"{cmd}")
            await asyncio.sleep(.5)
            output = await stdout.read(timeout=2) # Mentioning the timeout of 2 seconds
            result += f"#{cmd}\n"
            result += str(output)
        print(f"Result: {result}")

dev = Device("10.10.10.12", "dummy-user", "dummy-pass")

asyncio.run(dev.execute_commands(["ls -l", "pwd", "cat /etc/*release"]))
```